### PR TITLE
Bugfix - Pass parent properties to child text components

### DIFF
--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -62,6 +62,7 @@ class ParsedText extends React.Component {
       return (
         <ReactNative.Text
           key={`parsedText-${index}`}
+          allowFontScaling={this.props.allowFontScaling}
           {...props}
         />
       );


### PR DESCRIPTION
This is a workaround until https://github.com/taskrabbit/react-native-parsed-text/pull/27 is merged, or another solution is accepted.

As https://github.com/taskrabbit/react-native-parsed-text/pull/27 is still in review, it's not guaranteed that the new `childrenProps` property will become incorporated.

To avoid breaking changes, this implements the solution without any changes to the component usage by simply passing down the problematic property.

A further detailed breakdown of the problem can be found in https://github.com/taskrabbit/react-native-parsed-text/issues/29